### PR TITLE
Update INSTALL.md instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,6 +35,16 @@ We include the commands to install these dependencies for Ubuntu and Fedora belo
     $ sudo yum install gcc-c++ cmake make git gmp-devel procps-ng-devel boost-devel libsodium-devel
 ```
 
+
+### Dependencies Mac OS X
+
+On Mac OS X, install GMP from MacPorts (`port install gmp`).
+
+MacPorts does not write its libraries into standard system folders, so you
+might need to explicitly provide the paths to the header files and libraries by
+appending `CXXFLAGS=-I/opt/local/include LDFLAGS=-L/opt/local/lib` to the line
+above.
+
 ### Setting up git submodules and building
 
 Fetch dependencies from their GitHub repos:
@@ -43,28 +53,28 @@ Fetch dependencies from their GitHub repos:
     $ git submodule init && git submodule update
 ```
 
+Create a `build` folder:
+
+```bash
+    $ mkdir build; cd build
+```
+
 To create the Makefile:
 
 ```bash
-    $ cmake .
+    $ cmake ..
 ```
 
-Then, to compile the library, tests, and profiling harness, run this within the `libiop` directory:
+Then, to compile the library, tests, and profiling harness, run this within the `libiop/build`
+directory:
 
 ```bash
     $ make
 ```
 
-### Building on Mac OS X
-
-On Mac OS X, install GMP from MacPorts (`port install gmp`). Then disable the
-dependencies not easily supported under OS X, using:
-
-```bash
-    $ cmake -DWITH_PROCPS=OFF ..
-```
-
-MacPorts does not write its libraries into standard system folders, so you
-might need to explicitly provide the paths to the header files and libraries by
-appending `CXXFLAGS=-I/opt/local/include LDFLAGS=-L/opt/local/lib` to the line
-above.
+Build flags include:
+| Flag | Value | Description |
+| ---- | ----- | ----------- |
+| NDEBUG | false | Enables debug mode. |
+| WITH_PROCPS | ON | Enables `libprocps`, which is by default turned off since it is not supported on some systems such as MacOS. |
+| -GNinja |  | Builds with `Ninja` instead. |


### PR DESCRIPTION
Update build instructions: create a `build` folder, no need to provide extra flags for MacOS.

Note: I'm not sure if the `NDEBUG` flag currently works, it seems the code also defines a `DEBUG` flag, so this would require further investigation.