### PR TITLE
Caphash optimization

### DIFF
--- a/libiop/algebra/utils.hpp
+++ b/libiop/algebra/utils.hpp
@@ -19,6 +19,9 @@ void bitreverse_vector(std::vector<T> &a);
 template<typename T>
 std::vector<T> random_vector(const std::size_t count);
 
+template<typename T, typename U>
+bool compare_first(const std::pair<T, U> &a, const std::pair<T, U> &b);
+
 template<typename T>
 std::vector<T> all_subset_sums(const std::vector<T> &basis, const T& shift = 0)
 #if defined(__clang__)

--- a/libiop/algebra/utils.tcc
+++ b/libiop/algebra/utils.tcc
@@ -168,6 +168,12 @@ std::vector<T> random_vector(const std::size_t count)
     return result;
 }
 
+template<typename T, typename U>
+bool compare_first(const std::pair<T, U> &a, const std::pair<T, U> &b)
+{
+    return a.first < b.first;
+}
+
 template<typename FieldT>
 std::vector<FieldT> random_FieldT_vector(const std::size_t count)
 {

--- a/libiop/bcs/bcs_common.hpp
+++ b/libiop/bcs/bcs_common.hpp
@@ -25,6 +25,7 @@ template<typename FieldT, typename MT_hash_type>
 struct bcs_transformation_parameters {
     std::size_t security_parameter; /* TODO: possibly revisit in the future */
     bcs_hash_type hash_enum;
+    std::size_t cap_size;
 
     pow_parameters pow_params_;
 

--- a/libiop/bcs/bcs_common.hpp
+++ b/libiop/bcs/bcs_common.hpp
@@ -31,6 +31,7 @@ struct bcs_transformation_parameters {
     std::shared_ptr<hashchain<FieldT, MT_hash_type>> hashchain_;
     std::shared_ptr<leafhash<FieldT, MT_hash_type>> leafhasher_;
     two_to_one_hash_function<MT_hash_type> compression_hasher;
+    cap_hash_function<MT_hash_type> cap_hasher;
 };
 
 template<typename FieldT, typename MT_hash_type>

--- a/libiop/bcs/bcs_common.tcc
+++ b/libiop/bcs/bcs_common.tcc
@@ -471,6 +471,7 @@ void bcs_protocol<FieldT, MT_root_hash>::seal_interaction_registrations()
                 size,
                 this->parameters_.leafhasher_,
                 this->parameters_.compression_hasher,
+                this->parameters_.cap_hasher,
                 this->digest_len_bytes_,
                 make_zk,
                 this->parameters_.security_parameter);
@@ -724,6 +725,7 @@ void print_detailed_transcript_data(
             MT_size,
             params.leafhasher_,
             params.compression_hasher,
+            params.cap_hasher,
             digest_len_bytes,
             false,
             params.security_parameter);

--- a/libiop/bcs/bcs_common.tcc
+++ b/libiop/bcs/bcs_common.tcc
@@ -474,7 +474,8 @@ void bcs_protocol<FieldT, MT_root_hash>::seal_interaction_registrations()
                 this->parameters_.cap_hasher,
                 this->digest_len_bytes_,
                 make_zk,
-                this->parameters_.security_parameter);
+                this->parameters_.security_parameter,
+                this->parameters_.cap_size);
             this->Merkle_trees_.emplace_back(MT);
         }
     }

--- a/libiop/bcs/common_bcs_parameters.tcc
+++ b/libiop/bcs/common_bcs_parameters.tcc
@@ -15,10 +15,10 @@ bcs_transformation_parameters<FieldT, MT_root_hash> default_bcs_params(
     params.hash_enum = hash_type;
     /* TODO: Push setting leaf hash into internal BCS code. Currently 2 is fine, as leaf size is internally unused. */
     const size_t leaf_size = 2;
-    params.leafhasher_ = get_leafhash<FieldT, MT_root_hash>(hash_type, security_parameter, leaf_size);
+    params.leafhasher_ = get_leafhash<MT_root_hash, FieldT>(hash_type, security_parameter, leaf_size);
     params.compression_hasher = get_two_to_one_hash<MT_root_hash, FieldT>(hash_type, security_parameter);
-    params.hashchain_ =
-        get_hashchain<FieldT, MT_root_hash>(hash_type, security_parameter);
+    params.cap_hasher = get_cap_hash<MT_root_hash, FieldT>(hash_type, security_parameter);
+    params.hashchain_ = get_hashchain<FieldT, MT_root_hash>(hash_type, security_parameter);
 
     // Work per hash. Todo generalize this w/ proper explanations of work amounts
     const size_t work_per_hash = (hash_type == 1) ? 1 : 128;

--- a/libiop/bcs/common_bcs_parameters.tcc
+++ b/libiop/bcs/common_bcs_parameters.tcc
@@ -15,6 +15,7 @@ bcs_transformation_parameters<FieldT, MT_root_hash> default_bcs_params(
     params.hash_enum = hash_type;
     /* TODO: Push setting leaf hash into internal BCS code. Currently 2 is fine, as leaf size is internally unused. */
     const size_t leaf_size = 2;
+    params.cap_size = 2;
     params.leafhasher_ = get_leafhash<MT_root_hash, FieldT>(hash_type, security_parameter, leaf_size);
     params.compression_hasher = get_two_to_one_hash<MT_root_hash, FieldT>(hash_type, security_parameter);
     params.cap_hasher = get_cap_hash<MT_root_hash, FieldT>(hash_type, security_parameter);

--- a/libiop/bcs/hashing/algebraic_sponge.hpp
+++ b/libiop/bcs/hashing/algebraic_sponge.hpp
@@ -99,14 +99,15 @@ class algebraic_hashchain : public hashchain<FieldT, MT_root_type>
     void absorb_internal(const typename libff::enable_if<std::is_same<MT_root_type, FieldT>::value, MT_root_type>::type new_input);
 };
 
+/** The algebraic_vector_hash is used for both the algebraic leaf hash and cap hash. */
 template<typename FieldT>
-class algebraic_leafhash : public leafhash<FieldT, FieldT>
+class algebraic_vector_hash : public leafhash<FieldT, FieldT>
 {
     protected:
     std::shared_ptr<algebraic_sponge<FieldT>> sponge_;
 
     public:
-    algebraic_leafhash(
+    algebraic_vector_hash(
         std::shared_ptr<algebraic_sponge<FieldT>> sponge,
         size_t security_parameter);
     FieldT hash(const std::vector<FieldT> &leaf);
@@ -114,6 +115,9 @@ class algebraic_leafhash : public leafhash<FieldT, FieldT>
         const std::vector<FieldT> &leaf,
         const zk_salt_type &zk_salt);
 };
+
+template<typename FieldT>
+using algebraic_leafhash = algebraic_vector_hash<FieldT>;
 
 template<typename FieldT>
 class algebraic_two_to_one_hash

--- a/libiop/bcs/hashing/algebraic_sponge.tcc
+++ b/libiop/bcs/hashing/algebraic_sponge.tcc
@@ -206,7 +206,7 @@ MT_root_type algebraic_hashchain<FieldT, MT_root_type>::squeeze_root_type()
 }
 
 template<typename FieldT>
-algebraic_leafhash<FieldT>::algebraic_leafhash(
+algebraic_vector_hash<FieldT>::algebraic_vector_hash(
     std::shared_ptr<algebraic_sponge<FieldT>> sponge,
     size_t security_parameter) :
     sponge_(sponge->new_sponge())
@@ -218,7 +218,7 @@ algebraic_leafhash<FieldT>::algebraic_leafhash(
 }
 
 template<typename FieldT>
-FieldT algebraic_leafhash<FieldT>::hash(
+FieldT algebraic_vector_hash<FieldT>::hash(
     const std::vector<FieldT> &leaf)
 {
     this->sponge_->absorb(leaf);
@@ -228,7 +228,7 @@ FieldT algebraic_leafhash<FieldT>::hash(
 }
 
 template<typename FieldT>
-FieldT algebraic_leafhash<FieldT>::zk_hash(
+FieldT algebraic_vector_hash<FieldT>::zk_hash(
     const std::vector<FieldT> &leaf,
     const zk_salt_type &zk_salt)
 {

--- a/libiop/bcs/hashing/blake2b.cpp
+++ b/libiop/bcs/hashing/blake2b.cpp
@@ -65,7 +65,7 @@ binary_hash_digest blake2b_many_to_one_hash(const std::vector<binary_hash_digest
     /* see https://download.libsodium.org/doc/hashing/generic_hashing.html */
     const int status = crypto_generichash_blake2b((unsigned char*)&result[0],
                                                   digest_len_bytes,
-                                                  (result.empty() ? NULL : (unsigned char*)&input[0]),
+                                                  (input.empty() ? NULL : (unsigned char*)&input[0]),
                                                   input.size(),
                                                   NULL, 0);
     if (status != 0)

--- a/libiop/bcs/hashing/blake2b.cpp
+++ b/libiop/bcs/hashing/blake2b.cpp
@@ -73,4 +73,4 @@ std::size_t blake2b_integer_randomness_extractor(const binary_hash_digest &root,
     return result % upper_bound;
 }
 
-}
+} // namespace libiop

--- a/libiop/bcs/hashing/blake2b.hpp
+++ b/libiop/bcs/hashing/blake2b.hpp
@@ -58,6 +58,13 @@ class blake2b_leafhash : public leafhash<FieldT, binary_hash_digest>
         const zk_salt_type &zk_salt);
 };
 
+/* Many-to-one hash which takes in a vector. */
+template<typename hash_type>
+binary_hash_digest blake2b_vector_hash(const std::vector<hash_type> &data,
+                                       const std::size_t digest_len_bytes);
+
+/* This is a separate function from blake2b_vector_hash because we might want
+   to do some special handling on fields. */
 template<typename FieldT>
 binary_hash_digest blake2b_field_element_hash(const std::vector<FieldT> &data,
                                        const std::size_t digest_len_bytes);

--- a/libiop/bcs/hashing/blake2b.hpp
+++ b/libiop/bcs/hashing/blake2b.hpp
@@ -58,13 +58,8 @@ class blake2b_leafhash : public leafhash<FieldT, binary_hash_digest>
         const zk_salt_type &zk_salt);
 };
 
-/* Many-to-one hash which takes in a vector. */
-template<typename hash_type>
-binary_hash_digest blake2b_vector_hash(const std::vector<hash_type> &data,
-                                       const std::size_t digest_len_bytes);
-
-/* This is a separate function from blake2b_vector_hash because we might want
-   to do some special handling on fields. */
+/* Many-to-one hash which takes in a vector of field elements.
+   Behavior undefined when data is empty. */
 template<typename FieldT>
 binary_hash_digest blake2b_field_element_hash(const std::vector<FieldT> &data,
                                        const std::size_t digest_len_bytes);
@@ -80,11 +75,16 @@ std::size_t blake2b_integer_randomness_extractor(const binary_hash_digest &root,
                                                  const std::size_t upper_bound);
 
 binary_hash_digest blake2b_zk_element_hash(const std::vector<uint8_t> &first,
-                                    const std::size_t digest_len_bytes);
+                                           const std::size_t digest_len_bytes);
 
 binary_hash_digest blake2b_two_to_one_hash(const binary_hash_digest &first,
-                                    const binary_hash_digest &second,
-                                    const std::size_t digest_len_bytes);
+                                           const binary_hash_digest &second,
+                                           const std::size_t digest_len_bytes);
+
+/* Many-to-one hash which takes in a vector of binary_hash_digest.
+   Behavior undefined when data is empty. */
+binary_hash_digest blake2b_many_to_one_hash(const std::vector<binary_hash_digest> &data,
+                                            const std::size_t digest_len_bytes);
 
 } // namespace libiop
 

--- a/libiop/bcs/hashing/blake2b.tcc
+++ b/libiop/bcs/hashing/blake2b.tcc
@@ -135,33 +135,26 @@ binary_hash_digest blake2b_leafhash<FieldT>::zk_hash(
     return blake2b_two_to_one_hash(leaf_hash, zk_salt, this->digest_len_bytes_);
 }
 
-template<typename hash_type>
-binary_hash_digest blake2b_vector_hash(const std::vector<hash_type> &data,
-                                       const std::size_t digest_len_bytes)
-{
-
-    binary_hash_digest result(digest_len_bytes, 'X');
-
-    /* see https://download.libsodium.org/doc/hashing/generic_hashing.html */
-    const int status = crypto_generichash_blake2b((unsigned char*)&result[0],
-                                                  digest_len_bytes,
-                                                  (result.empty() ? NULL : (unsigned char*)&data[0]),
-                                                  sizeof(hash_type) * data.size(),
-                                                  NULL, 0);
-    if (status != 0)
-    {
-        throw std::runtime_error("Got non-zero status from crypto_generichash_blake2b. (Is digest_len_bytes correct?)");
-    }
-    return result;
-}
-
 // TODO: Consider how this interacts with field elems being in montgomery form
 // don't we need to make them in canonical form first?
 template<typename FieldT>
 binary_hash_digest blake2b_field_element_hash(const std::vector<FieldT> &data,
                                               const std::size_t digest_len_bytes)
 {
-    return blake2b_vector_hash<FieldT>(data, digest_len_bytes);
+    binary_hash_digest result(digest_len_bytes, 'X');
+
+    /* see https://download.libsodium.org/doc/hashing/generic_hashing.html */
+    const int status = crypto_generichash_blake2b((unsigned char*)&result[0],
+                                                  digest_len_bytes,
+                                                  (result.empty() ? NULL : (unsigned char*)&data[0]),
+                                                  sizeof(FieldT) * data.size(),
+                                                  NULL, 0);
+    if (status != 0)
+    {
+        throw std::runtime_error("Got non-zero status from crypto_generichash_blake2b. (Is digest_len_bytes correct?)");
+    }
+
+    return result;
 }
 
 template<typename FieldT>

--- a/libiop/bcs/hashing/blake2b.tcc
+++ b/libiop/bcs/hashing/blake2b.tcc
@@ -135,10 +135,8 @@ binary_hash_digest blake2b_leafhash<FieldT>::zk_hash(
     return blake2b_two_to_one_hash(leaf_hash, zk_salt, this->digest_len_bytes_);
 }
 
-// TODO: Consider how this interacts with field elems being in montgomery form
-// don't we need to make them in canonical form first?
-template<typename FieldT>
-binary_hash_digest blake2b_field_element_hash(const std::vector<FieldT> &data,
+template<typename hash_type>
+binary_hash_digest blake2b_vector_hash(const std::vector<hash_type> &data,
                                        const std::size_t digest_len_bytes)
 {
 
@@ -148,15 +146,22 @@ binary_hash_digest blake2b_field_element_hash(const std::vector<FieldT> &data,
     const int status = crypto_generichash_blake2b((unsigned char*)&result[0],
                                                   digest_len_bytes,
                                                   (result.empty() ? NULL : (unsigned char*)&data[0]),
-                                                  sizeof(FieldT) * data.size(),
+                                                  sizeof(hash_type) * data.size(),
                                                   NULL, 0);
     if (status != 0)
     {
         throw std::runtime_error("Got non-zero status from crypto_generichash_blake2b. (Is digest_len_bytes correct?)");
     }
-
-
     return result;
+}
+
+// TODO: Consider how this interacts with field elems being in montgomery form
+// don't we need to make them in canonical form first?
+template<typename FieldT>
+binary_hash_digest blake2b_field_element_hash(const std::vector<FieldT> &data,
+                                              const std::size_t digest_len_bytes)
+{
+    return blake2b_vector_hash<FieldT>(data, digest_len_bytes);
 }
 
 template<typename FieldT>
@@ -256,4 +261,4 @@ std::vector<FieldT> blake2b_FieldT_randomness_extractor(const binary_hash_digest
     return result;
 }
 
-}
+} // namespace libiop

--- a/libiop/bcs/hashing/dummy_algebraic_hash.hpp
+++ b/libiop/bcs/hashing/dummy_algebraic_hash.hpp
@@ -63,6 +63,9 @@ FieldT dummy_algebraic_two_to_one_hash(
     const FieldT &second,
     const std::size_t digest_len_bytes);
 
+template<typename FieldT>
+FieldT dummy_algebraic_cap_hash(const std::vector<FieldT> &data, const std::size_t digest_len_bytes);
+
 } // namespace libiop
 
 #include "libiop/bcs/hashing/dummy_algebraic_hash.tcc"

--- a/libiop/bcs/hashing/dummy_algebraic_hash.tcc
+++ b/libiop/bcs/hashing/dummy_algebraic_hash.tcc
@@ -147,4 +147,15 @@ FieldT dummy_algebraic_two_to_one_hash(
     return FieldT(2) * first + second;
 }
 
+template<typename FieldT>
+FieldT dummy_algebraic_cap_hash(const std::vector<FieldT> &data, const std::size_t digest_len_bytes)
+{
+    FieldT sum = FieldT::zero();
+    for (size_t i = 0; i < data.size(); i++)
+    {
+        sum += FieldT(i) * data[i];
+    }
+    return sum;
+}
+
 }

--- a/libiop/bcs/hashing/dummy_algebraic_hash.tcc
+++ b/libiop/bcs/hashing/dummy_algebraic_hash.tcc
@@ -117,7 +117,7 @@ FieldT dummy_algebraic_leafhash<FieldT>::hash(const std::vector<FieldT> &leaf)
     FieldT sum = FieldT::zero();
     for (size_t i = 0; i < leaf.size(); i++)
     {
-        sum += FieldT(i) * leaf[i];
+        sum += FieldT(i + 1) * leaf[i]; // Add one, otherwise the 0th index is unused.
     }
     return sum;
 }
@@ -153,8 +153,9 @@ FieldT dummy_algebraic_cap_hash(const std::vector<FieldT> &data, const std::size
     FieldT sum = FieldT::zero();
     for (size_t i = 0; i < data.size(); i++)
     {
-        sum += FieldT(i) * data[i];
+        sum += FieldT(i + 1) * data[i]; // Add one, otherwise the 0th index is unused.
     }
+
     return sum;
 }
 

--- a/libiop/bcs/hashing/hash_enum.hpp
+++ b/libiop/bcs/hashing/hash_enum.hpp
@@ -30,14 +30,17 @@ static const char* bcs_hash_type_names[] = {"", "blake2b", "poseidon with Starkw
 template<typename FieldT, typename MT_root_type>
 std::shared_ptr<hashchain<FieldT, MT_root_type>> get_hashchain(bcs_hash_type hash_type, size_t security_parameter);
 
-template<typename FieldT, typename leaf_hash_type>
+template<typename leaf_hash_type, typename FieldT>
 std::shared_ptr<leafhash<FieldT, leaf_hash_type>> get_leafhash(
-    const bcs_hash_type hash_type, 
-    const size_t security_parameter, 
+    const bcs_hash_type hash_type,
+    const size_t security_parameter,
     const size_t leaf_size);
 
 template<typename hash_type, typename FieldT>
 two_to_one_hash_function<hash_type> get_two_to_one_hash(const bcs_hash_type hash_enum, const size_t security_parameter);
+
+template<typename hash_type, typename FieldT>
+cap_hash_function<hash_type> get_cap_hash(const bcs_hash_type hash_enum, const size_t security_parameter);
 
 }
 #include "libiop/bcs/hashing/hash_enum.tcc"

--- a/libiop/bcs/hashing/hash_enum.tcc
+++ b/libiop/bcs/hashing/hash_enum.tcc
@@ -173,7 +173,7 @@ cap_hash_function<hash_type> get_cap_hash_internal(
 {
     if (hash_enum == blake2b_type)
     {
-        return blake2b_vector_hash<hash_type>;
+        return blake2b_many_to_one_hash;
     }
     throw std::invalid_argument("bcs_hash_type unknown");
 }

--- a/libiop/bcs/hashing/hash_enum.tcc
+++ b/libiop/bcs/hashing/hash_enum.tcc
@@ -58,7 +58,7 @@ std::shared_ptr<hashchain<FieldT, MT_root_type>> get_hashchain_internal(
     {
         return std::make_shared<blake2b_hashchain<FieldT, MT_root_type>>(security_parameter);
     }
-    throw std::invalid_argument("bcs_hash_type unknown");
+    throw std::invalid_argument("bcs_hash_type unknown (blake2b hashchain)");
 }
 
 
@@ -80,7 +80,7 @@ std::shared_ptr<leafhash<FieldT, leaf_hash_type>> get_leafhash_internal(
     {
         return std::make_shared<blake2b_leafhash<FieldT>>(security_parameter);
     }
-    throw std::invalid_argument("bcs_hash_type unknown");
+    throw std::invalid_argument("bcs_hash_type unknown (blake2b leaf hash)");
 }
 
 /* Algebraic leafhash case */
@@ -125,7 +125,7 @@ two_to_one_hash_function<hash_type> get_two_to_one_hash_internal(
     {
         return blake2b_two_to_one_hash;
     }
-    throw std::invalid_argument("bcs_hash_type unknown");
+    throw std::invalid_argument("bcs_hash_type unknown (blake2b two to one hash)");
 }
 
 /* algebraic 2->1 hash */
@@ -174,7 +174,7 @@ cap_hash_function<hash_type> get_cap_hash_internal(
     {
         return blake2b_many_to_one_hash;
     }
-    throw std::invalid_argument("bcs_hash_type unknown");
+    throw std::invalid_argument("bcs_hash_type unknown (blake2b cap hash)");
 }
 
 /* Algebraic 2^n->1 hash. */

--- a/libiop/bcs/hashing/hash_enum.tcc
+++ b/libiop/bcs/hashing/hash_enum.tcc
@@ -100,9 +100,8 @@ std::shared_ptr<leafhash<FieldT, leaf_hash_type>> get_leafhash_internal(
         poseidon_params<FieldT> params = get_poseidon_parameters<FieldT>(hash_enum);
         /* security parameter is -1 b/c */
         std::shared_ptr<poseidon<FieldT>> permutation = std::make_shared<poseidon<FieldT>>(params);
-        std::shared_ptr<leafhash<FieldT, leaf_hash_type>> leafhasher = std::make_shared<algebraic_leafhash<FieldT>>(
-            permutation, 
-            security_parameter - 1);
+        std::shared_ptr<leafhash<FieldT, leaf_hash_type>> leafhasher =
+            std::make_shared<algebraic_leafhash<FieldT>>(permutation, security_parameter - 1);
         return leafhasher;
     }
     throw std::invalid_argument("bcs_hash_type unknown (algebraic leaf hash)");
@@ -149,7 +148,7 @@ two_to_one_hash_function<FieldT> get_two_to_one_hash_internal(
            as this reference has to live after the function terminates */
         std::shared_ptr<algebraic_two_to_one_hash<FieldT>> hash_class = 
             std::make_shared<algebraic_two_to_one_hash<FieldT>>(permutation, security_parameter - 1);
-        std::function<FieldT(const FieldT&, const FieldT&, const std::size_t)> f = [permutation, hash_class](const FieldT& left, const FieldT& right, const std::size_t unused) -> FieldT 
+        std::function<FieldT(const FieldT&, const FieldT&, const std::size_t)> f = [permutation, hash_class](const FieldT& left, const FieldT& right, const std::size_t unused) -> FieldT
         {
             return hash_class->hash(left, right);
         };
@@ -185,25 +184,25 @@ cap_hash_function<FieldT> get_cap_hash_internal(
     const bcs_hash_type hash_enum,
     const size_t security_parameter)
 {
-    // if (hash_enum == starkware_poseidon_type || hash_enum == high_alpha_poseidon_type)
-    // {
-    //     if (security_parameter != 128)
-    //     {
-    //         throw std::invalid_argument("Poseidon only supported for 128 bit soundness.");
-    //     }
-    //     poseidon_params<FieldT> params = get_poseidon_parameters<FieldT>(hash_enum);
-    //     /* security parameter is -1 b/c */
-    //     std::shared_ptr<algebraic_sponge<FieldT>> permutation = std::make_shared<poseidon<FieldT>>(params);
-    //     /* We explicitly place this on heap with no destructor,
-    //        as this reference has to live after the function terminates */
-    //     std::shared_ptr<algebraic_two_to_one_hash<FieldT>> hash_class =
-    //         std::make_shared<algebraic_two_to_one_hash<FieldT>>(permutation, security_parameter - 1);
-    //     std::function<FieldT(const FieldT&, const FieldT&, const std::size_t)> f = [permutation, hash_class](const FieldT& left, const FieldT& right, const std::size_t unused) -> FieldT 
-    //     {
-    //         return hash_class->hash(left, right);
-    //     };
-    //     return f;
-    // }
+    if (hash_enum == starkware_poseidon_type || hash_enum == high_alpha_poseidon_type)
+    {
+        if (security_parameter != 128)
+        {
+            throw std::invalid_argument("Poseidon only supported for 128 bit soundness.");
+        }
+        poseidon_params<FieldT> params = get_poseidon_parameters<FieldT>(hash_enum);
+        /* security parameter is -1 b/c */
+        std::shared_ptr<algebraic_sponge<FieldT>> permutation = std::make_shared<poseidon<FieldT>>(params);
+        /* We explicitly place this on heap with no destructor,
+           as this reference has to live after the function terminates */
+        std::shared_ptr<algebraic_vector_hash<FieldT>> hash_class =
+            std::make_shared<algebraic_vector_hash<FieldT>>(permutation, security_parameter - 1);
+        std::function<FieldT(const std::vector<FieldT> &leaf, const std::size_t)> f = [permutation, hash_class](const std::vector<FieldT> &leaf, const std::size_t unused) -> FieldT
+        {
+            return hash_class->hash(leaf);
+        };
+        return f;
+    }
     throw std::invalid_argument("bcs_hash_type unknown (algebraic cap hash)");
 }
 

--- a/libiop/bcs/hashing/hashing.hpp
+++ b/libiop/bcs/hashing/hashing.hpp
@@ -52,6 +52,10 @@ class leafhash
 template<typename hash_type>
 using two_to_one_hash_function = std::function<hash_type(const hash_type&, const hash_type&, const std::size_t)>;
 
+/* Function used for cap hash of merkle tree which takes in a vector of size 2^n. */
+template<typename hash_type>
+using cap_hash_function = std::function<hash_type(const std::vector<hash_type>&, const std::size_t)>;
+
 /* Sizeof algebraic hash */
 template<typename hash_type>
 size_t get_hash_size(const typename libff::enable_if<!std::is_same<hash_type, binary_hash_digest>::value, hash_type>::type h)

--- a/libiop/bcs/merkle_tree.hpp
+++ b/libiop/bcs/merkle_tree.hpp
@@ -126,6 +126,8 @@ public:
 
     hash_digest_type get_root() const;
 
+    /* These two functions do not currently work if the given positions aren't sorted or
+       have duplicates, AND the tree is set to be zero knowledge. */
     merkle_tree_set_membership_proof<hash_digest_type> get_set_membership_proof(
         const std::vector<std::size_t> &positions) const;
     bool validate_set_membership_proof(

--- a/libiop/bcs/merkle_tree.hpp
+++ b/libiop/bcs/merkle_tree.hpp
@@ -20,7 +20,7 @@
 
 namespace libiop {
 
-/* Authentication paths for a set of positions */
+/** Authentication paths for a set of positions. */
 template<typename hash_digest_type>
 struct merkle_tree_set_membership_proof {
     std::vector<hash_digest_type> auxiliary_hashes;
@@ -46,9 +46,12 @@ template<typename FieldT, typename hash_digest_type>
 class merkle_tree {
 protected:
     bool constructed_;
-    /* inner_nodes_ is a vector of the (num_leaves - 1) nodes in the tree, with the root at
-       index 0, left child at 1, right child at 2, etc. If cap_size_ is greater than 2, the
-       first (log_2(cap_size_) - 1) layers under the root are empty to make the math easier. */
+    /**
+     * inner_nodes_ is a vector of the `2 * num_leaves_ - 1` nodes in the tree, with the root
+     * at index 0, left child at 1, right child at 2, etc. If cap_size_ is greater than 2, the
+     * first `log_2(cap_size_) - 1` layers under (and not including) the root are empty to make
+     * the math easier.
+     */
     std::vector<hash_digest_type> inner_nodes_;
 
     std::size_t num_leaves_;
@@ -57,17 +60,21 @@ protected:
     std::size_t digest_len_bytes_;
     bool make_zk_;
     std::size_t num_zk_bytes_;
-    /* The top log_2(cap_size_) layers are hashed with a single computation to improve efficiency.
-       The root along with its cap_size_ direct children are referred to as the "cap," and the
-       operation that transforms these children to the root is the cap hash.
-       See https://github.com/scipr-lab/libiop/issues/41. */
+    /**
+     * The top `log_2(cap_size_)` layers are hashed with a single computation to improve efficiency.
+     * The root along with its cap_size_ direct children are referred to as the "cap," and the
+     * operation that transforms these children to the root is the cap hash.
+     * See https://github.com/scipr-lab/libiop/issues/41.
+     */
     cap_hash_function<hash_digest_type> cap_hasher_;
-    /* cap_size_ is the number of direct children the root has. It must be a power of 2 and at
-       least 2. For example if cap_size == 4, the root has 4 children, and in inner_nodes_ the
-       indices 1 and 2 are unused. */
+    /**
+     * cap_size_ is the number of direct children the root has. It must be a power of 2 and at
+     * least 2. For example if cap_size == 4, the root has 4 children, and in inner_nodes_ the
+     * indices 1 and 2 are unused.
+     */
     std::size_t cap_size_;
 
-    /* Each element will be hashed (individually) to produce a random hash digest. */
+    /** Each element will be hashed (individually) to produce a random hash digest. */
     std::vector<zk_salt_type> zk_leaf_randomness_elements_;
     void sample_leaf_randomness();
     void compute_inner_nodes();
@@ -81,10 +88,12 @@ protected:
     std::size_t cap_children_start() const; // Inclusive.
     std::size_t cap_children_end() const; // Exclusive.
 public:
-    /* Create a merkle tree with the given configuration.
-    If make_zk is true, 2 * security parameter random bytes will be appended to each leaf
-    before hashing, to prevent a low entropy leaf value from being inferred from its hash.
-    cap_size is the number of children of the root and must be a power of 2. */
+    /**
+     * Create a merkle tree with the given configuration.
+     * If make_zk is true, 2 * security parameter random bytes will be appended to each leaf
+     * before hashing, to prevent a low entropy leaf value from being inferred from its hash.
+     * cap_size is the number of children of the root and must be a power of 2.
+     */
     merkle_tree(const std::size_t num_leaves,
                 const std::shared_ptr<leafhash<FieldT, hash_digest_type>> &leaf_hasher,
                 const two_to_one_hash_function<hash_digest_type> &node_hasher,
@@ -94,31 +103,35 @@ public:
                 const std::size_t security_parameter,
                 const std::size_t cap_size=2);
 
-    /** This treats each leaf as a column.
-     * e.g. The ith leaf is the vector formed by leaf_contents[j][i] for all j */
+    /**
+     * This treats each leaf as a column.
+     * e.g. The ith leaf is the vector formed by leaf_contents[j][i] for all j.
+     */
     void construct(const std::vector<std::shared_ptr<std::vector<FieldT>>> &leaf_contents);
     // TODO: Remove this overload in favor of only using the former
     void construct(const std::vector<std::vector<FieldT> > &leaf_contents);
-    /** Leaf contents is a table with `r` rows
-     *  (`r` typically being the number of oracles)
-     *  and (MT_num_leaves * coset_serialization_size) columns.
-     *  Each MT leaf is the serialization of a table with `r` rows,
-     *  and coset_serialization_size columns.
+    /**
+     * Leaf contents is a table with `r` rows
+     * (`r` typically being the number of oracles)
+     * and (MT_num_leaves * coset_serialization_size) columns.
+     * Each MT leaf is the serialization of a table with `r` rows,
+     * and coset_serialization_size columns.
      *
-     *  This is done here rather than the BCS layer to avoid needing to copy the data,
-     *  as this will take a significant amount of memory.
+     * This is done here rather than the BCS layer to avoid needing to copy the data,
+     * as this will take a significant amount of memory.
      */
     void construct_with_leaves_serialized_by_cosets(
         const std::vector<std::shared_ptr<std::vector<FieldT>>> &leaf_contents,
         size_t coset_serialization_size);
 
-    /** Takes in a set of query positions to input oracles to a domain of size:
-     *  `num_leaves * coset_serialization_size`,
-     *  and the associated evaluations for each query position.
+    /**
+     * Takes in a set of query positions to input oracles to a domain of size:
+     * `num_leaves * coset_serialization_size`,
+     * and the associated evaluations for each query position.
      *
-     *  This function then serializes these evaluations into leaf entries.
-     *  The rows of a leaf entry are the same as in the eva
-    */
+     * This function then serializes these evaluations into leaf entries.
+     * The rows of a leaf entry are the same as in the eva
+     */
     std::vector<std::vector<FieldT>> serialize_leaf_values_by_coset(
         const std::vector<size_t> &query_positions,
         const std::vector<std::vector<FieldT> > &query_responses,
@@ -136,9 +149,11 @@ public:
         const std::vector<std::vector<FieldT>> &leaf_contents,
         const merkle_tree_set_membership_proof<hash_digest_type> &proof);
 
-    /** Returns a number that is proportional to the hashing runtime of verifying a set membership
-     *  proof. Each two-to-one hash is counted as 2 units, and each input of the cap hash is 1 unit.
-     *  Leaf hashes are not counted. */
+    /**
+     * Returns a number that is proportional to the hashing runtime of verifying a set membership
+     * proof. Each two-to-one hash is counted as 2 units, and each input of the cap hash is 1 unit.
+     * Leaf hashes are not counted.
+     */
     size_t count_internal_hash_complexity_to_verify_set_membership(
         const std::vector<std::size_t> &positions) const;
 

--- a/libiop/bcs/merkle_tree.hpp
+++ b/libiop/bcs/merkle_tree.hpp
@@ -136,8 +136,10 @@ public:
         const std::vector<std::vector<FieldT>> &leaf_contents,
         const merkle_tree_set_membership_proof<hash_digest_type> &proof);
 
-    /* Returns number of two to one hashes */
-    size_t count_hashes_to_verify_set_membership_proof(
+    /** Returns a number that is proportional to the hashing runtime of verifying a set membership
+     *  proof. Each two-to-one hash is counted as 2 units, and each input of the cap hash is 1 unit.
+     *  Leaf hashes are not counted. */
+    size_t count_internal_hash_complexity_to_verify_set_membership(
         const std::vector<std::size_t> &positions) const;
 
     std::size_t num_leaves() const;

--- a/libiop/bcs/merkle_tree.hpp
+++ b/libiop/bcs/merkle_tree.hpp
@@ -54,6 +54,8 @@ protected:
     std::size_t digest_len_bytes_;
     bool make_zk_;
     std::size_t num_zk_bytes_;
+    cap_hash_function<hash_digest_type> cap_hasher_;
+    std::size_t cap_size_;
 
     /* Each element will be hashed (individually) to produce a random hash digest. */
     std::vector<zk_salt_type> zk_leaf_randomness_elements_;
@@ -62,14 +64,16 @@ protected:
 public:
     /* Create a merkle tree with the given configuration.
     If make_zk is true, 2 * security parameter random bytes will be appended to each leaf
-    before hashing, to prevent a low entropy leaf value from being inferred
-    from its hash. */
+    before hashing, to prevent a low entropy leaf value from being inferred from its hash.
+    cap_size is the number of children of the root and must be a power of 2. */
     merkle_tree(const std::size_t num_leaves,
                 const std::shared_ptr<leafhash<FieldT, hash_digest_type>> &leaf_hasher,
                 const two_to_one_hash_function<hash_digest_type> &node_hasher,
+                const cap_hash_function<hash_digest_type> &cap_hasher,
                 const std::size_t digest_len_bytes,
                 const bool make_zk,
-                const std::size_t security_parameter);
+                const std::size_t security_parameter,
+                const std::size_t cap_size=2);
 
     /** This treats each leaf as a column.
      * e.g. The ith leaf is the vector formed by leaf_contents[j][i] for all j */

--- a/libiop/bcs/merkle_tree.tcc
+++ b/libiop/bcs/merkle_tree.tcc
@@ -211,8 +211,9 @@ std::vector<std::vector<FieldT>> merkle_tree<FieldT, hash_digest_type>::serializ
 template<typename FieldT, typename hash_digest_type>
 void merkle_tree<FieldT, hash_digest_type>::compute_inner_nodes()
 {
-    /* n is the first index of the layer we're about to compute. It starts at the bottom layer.
-       This hack works because num_leaves is the index of the right child of the bottom-left node. */
+    /* n is the first index of the layer we're about to compute. It starts at the bottom-left most
+       inner node. This hack works because num_leaves is the index of the right child of the
+       bottom-left inner node. */
     size_t n = this->parent_of(this->num_leaves_);
     while (true)
     {
@@ -349,8 +350,8 @@ merkle_tree_set_membership_proof<hash_digest_type>
         std::swap(S, new_S);
     }
 
-    // Add the cap, including the root's direct children and the root.
-    // The only elements should be the cap (not including the root).
+    // Add the cap, i.e. the root's direct children.
+    // The only elements should be the cap.
     assert(S.size() <= this->cap_size_);
     auto it = S.begin();
     // Iterate over every direct child of the root, and add the ones not obtainable from positions.
@@ -497,8 +498,10 @@ bool merkle_tree<FieldT, hash_digest_type>::validate_set_membership_proof(
                 }
                 else
                 {
-                    /* b) Our right sibling is in S. So don't need auxiliary and skip over the
-                       right sibling The parent will be obtained) next iteration. */
+                    /* b) Our right sibling is in S. So don't need
+                       auxiliary and skip over the right sibling.
+                       (Note that only one parent will be processed.)
+                    */
                     right_hash = next_it->second;
                     ++next_it;
                 }

--- a/libiop/bcs/merkle_tree.tcc
+++ b/libiop/bcs/merkle_tree.tcc
@@ -14,20 +14,29 @@ merkle_tree<FieldT, hash_digest_type>::merkle_tree(
     const std::size_t num_leaves,
     const std::shared_ptr<leafhash<FieldT, hash_digest_type>> &leaf_hasher,
     const two_to_one_hash_function<hash_digest_type> &node_hasher,
+    const cap_hash_function<hash_digest_type> &cap_hasher,
     const std::size_t digest_len_bytes,
     const bool make_zk,
-    const std::size_t security_parameter) :
+    const std::size_t security_parameter,
+    const std::size_t cap_size) :
     num_leaves_(num_leaves),
     leaf_hasher_(leaf_hasher),
     node_hasher_(node_hasher),
+    cap_hasher_(cap_hasher),
     digest_len_bytes_(digest_len_bytes),
     make_zk_(make_zk),
-    num_zk_bytes_((security_parameter * 2 + 7) / 8) /* = ceil((2 * security_parameter_bits) / 8) */
+    num_zk_bytes_((security_parameter * 2 + 7) / 8), /* = ceil((2 * security_parameter_bits) / 8) */
+    cap_size_(cap_size)
 {
     if (num_leaves < 2 || !libff::is_power_of_2(num_leaves))
     {
         /* Handling num_leaves-1 Merkle trees adds little complexity but is not really worth it */
         throw std::invalid_argument("Merkle tree size must be a power of two, and at least 2.");
+    }
+
+    if (cap_size < 2 || !libff::is_power_of_2(cap_size))
+    {
+        throw std::invalid_argument("Merkle tree cap size must be a power of two, and at least 2.");
     }
 
     this->constructed_ = false;

--- a/libiop/bcs/pow.tcc
+++ b/libiop/bcs/pow.tcc
@@ -76,7 +76,7 @@ hash_digest_type pow<FieldT, hash_digest_type>::solve_pow_internal(
     const typename libff::enable_if<std::is_same<hash_digest_type, FieldT>::value, hash_digest_type>::type challenge) const
 {
     FieldT pow = FieldT::zero();
-    while (this->verify_pow(node_hasher, challenge, pow) == false)
+    while (!this->verify_pow(node_hasher, challenge, pow))
     {
         pow += FieldT::one();
     }
@@ -93,8 +93,9 @@ hash_digest_type pow<FieldT, hash_digest_type>::solve_pow_internal(
 
     size_t num_words = pow.length() / sizeof(size_t);
     size_t pow_int = 0;
-    while (this->verify_pow(node_hasher, challenge, pow) == false)
+    while (!this->verify_pow(node_hasher, challenge, pow))
     {
+        // printf("Trying %zx\n", pow[(num_words - 1)*sizeof(size_t)]);
         std::memcpy(&pow[(num_words - 1)*sizeof(size_t)], &pow_int, sizeof(size_t));
         pow_int += 1;
     }
@@ -147,15 +148,11 @@ bool pow<FieldT, hash_digest_type>::verify_pow_internal(
     size_t least_significant_word;
     std::memcpy(&least_significant_word, &hash[(num_words - 1)*sizeof(size_t)], sizeof(size_t));
     size_t relevant_bits = least_significant_word & ((1 << this->parameters_.pow_bitlen()) - 1);
-    if (relevant_bits <= this->parameters_.pow_upperbound())
-    {    
-        // printf("%d\n", (1 << this->parameters_.pow_bitlen()));
-        // printf("%zu\n", least_significant_word);
-        // printf("%\n", relevant_bits);
-        // print_string_in_hex(hash);
-        return true;
-    }
-    return false;
+    // printf("upper bound: %zx\n", this->parameters_.pow_upperbound());
+    // printf("bit mask: %zx\n", (1 << this->parameters_.pow_bitlen()) - 1);
+    // printf("least significant word: %zx\n", least_significant_word);
+    // printf("relevant bits: %zx\n", relevant_bits);
+    return relevant_bits <= this->parameters_.pow_upperbound();
 }
 
 } // libiop

--- a/libiop/bcs/pow.tcc
+++ b/libiop/bcs/pow.tcc
@@ -95,7 +95,6 @@ hash_digest_type pow<FieldT, hash_digest_type>::solve_pow_internal(
     size_t pow_int = 0;
     while (!this->verify_pow(node_hasher, challenge, pow))
     {
-        // printf("Trying %zx\n", pow[(num_words - 1)*sizeof(size_t)]);
         std::memcpy(&pow[(num_words - 1)*sizeof(size_t)], &pow_int, sizeof(size_t));
         pow_int += 1;
     }
@@ -148,10 +147,6 @@ bool pow<FieldT, hash_digest_type>::verify_pow_internal(
     size_t least_significant_word;
     std::memcpy(&least_significant_word, &hash[(num_words - 1)*sizeof(size_t)], sizeof(size_t));
     size_t relevant_bits = least_significant_word & ((1 << this->parameters_.pow_bitlen()) - 1);
-    // printf("upper bound: %zx\n", this->parameters_.pow_upperbound());
-    // printf("bit mask: %zx\n", (1 << this->parameters_.pow_bitlen()) - 1);
-    // printf("least significant word: %zx\n", least_significant_word);
-    // printf("relevant bits: %zx\n", relevant_bits);
     return relevant_bits <= this->parameters_.pow_upperbound();
 }
 

--- a/libiop/tests/bcs/test_bcs_transformation.cpp
+++ b/libiop/tests/bcs/test_bcs_transformation.cpp
@@ -44,7 +44,7 @@ void set_bcs_parameters_leafhash(bcs_transformation_parameters<FieldT, MT_root_h
 {
     params.leafhasher_ = std::make_shared<blake2b_leafhash<FieldT>>(security_parameter);
     params.compression_hasher = blake2b_two_to_one_hash;
-    params.cap_hasher = blake2b_vector_hash<binary_hash_digest>;
+    params.cap_hasher = blake2b_many_to_one_hash;
 }
 
 // Algebraic case

--- a/libiop/tests/bcs/test_bcs_transformation.cpp
+++ b/libiop/tests/bcs/test_bcs_transformation.cpp
@@ -44,6 +44,7 @@ void set_bcs_parameters_leafhash(bcs_transformation_parameters<FieldT, MT_root_h
 {
     params.leafhasher_ = std::make_shared<blake2b_leafhash<FieldT>>(security_parameter);
     params.compression_hasher = blake2b_two_to_one_hash;
+    params.cap_hasher = blake2b_vector_hash<binary_hash_digest>;
 }
 
 // Algebraic case
@@ -52,7 +53,8 @@ template<typename FieldT, typename MT_root_hash,
 void set_bcs_parameters_leafhash(bcs_transformation_parameters<FieldT, MT_root_hash> &params)
 {
     params.leafhasher_ = std::make_shared<dummy_algebraic_leafhash<FieldT>>();
-    params.compression_hasher = dummy_algebraic_two_to_one_hash<MT_root_hash>;
+    params.compression_hasher = dummy_algebraic_two_to_one_hash<FieldT>;
+    params.cap_hasher = dummy_algebraic_cap_hash<FieldT>;
 }
 
 template<typename FieldT, typename MT_root_hash>

--- a/libiop/tests/bcs/test_bcs_transformation.cpp
+++ b/libiop/tests/bcs/test_bcs_transformation.cpp
@@ -72,6 +72,7 @@ bcs_transformation_parameters<FieldT, MT_root_hash> get_bcs_parameters(bool alge
         bcs_parameters.hash_enum = bcs_hash_type::blake2b_type;
     }
     set_bcs_parameters_leafhash<FieldT, MT_root_hash>(bcs_parameters);
+    bcs_parameters.cap_size = 2;
 
     return bcs_parameters;
 }

--- a/libiop/tests/bcs/test_merkle_tree.cpp
+++ b/libiop/tests/bcs/test_merkle_tree.cpp
@@ -295,6 +295,8 @@ TEST(MerkleTreeZKTest, RandomMultiTest) {
     run_random_multi_test(1ull << 16, digest_len_bytes, make_zk, security_parameter, 256, 100);
 }
 
+/** Verify that count_internal_hash_complexity_to_verify_set_membership is correct for a fixed tree
+ *  size and query set, for various cap sizes. */
 TEST(MerkleTreeHashCountTest, SimpleTest)
 {
     typedef libff::gf64 FieldT;
@@ -304,16 +306,24 @@ TEST(MerkleTreeHashCountTest, SimpleTest)
     const size_t hash_length = 32;
     const bool algebraic_hash = false;
 
-    merkle_tree<FieldT, binary_hash_digest> tree = new_MT<FieldT, binary_hash_digest>(
-        num_leaves,
-        hash_length,
-        make_zk,
-        security_parameter);
+    const std::vector<size_t> cap_sizes = {2, 4, 8};
+    const std::vector<size_t> expected_num_hashes = {12, 10, 8};
 
-    std::vector<size_t> positions = {1, 3, 6, 7};
-    size_t expected_num_hashes = 6;
-    size_t actual_num_hashes = tree.count_hashes_to_verify_set_membership_proof(positions);
-    ASSERT_EQ(expected_num_hashes, actual_num_hashes);
+    const std::vector<size_t> positions = {1, 3, 6, 7};
+
+    for (size_t i = 0; i < cap_sizes.size(); i++)
+    {
+        merkle_tree<FieldT, binary_hash_digest> tree = new_MT<FieldT, binary_hash_digest>(
+            num_leaves,
+            hash_length,
+            make_zk,
+            security_parameter,
+            cap_sizes[i]);
+
+        size_t actual_num_hashes = tree.count_internal_hash_complexity_to_verify_set_membership(
+            positions);
+        ASSERT_EQ(expected_num_hashes[i], actual_num_hashes);
+    }
 }
 
 }

--- a/libiop/tests/bcs/test_merkle_tree.cpp
+++ b/libiop/tests/bcs/test_merkle_tree.cpp
@@ -245,7 +245,7 @@ void run_random_multi_test(const size_t size, const size_t digest_len_bytes, con
     {
         std::vector<size_t> subset_elements;
         std::vector<std::vector<FieldT>> subset_leaves;
-        /* The commented-out code generates subsets that are unsorted and may be repeats.
+        /* TODO: The commented-out code generates subsets that are unsorted and may be repeats.
            They are not used because the code currently cannot handle these cases if it is
            zero knowledge. */
         // for (size_t j = 0; j < subset_size; j++)

--- a/libiop/tests/bcs/test_merkle_tree.cpp
+++ b/libiop/tests/bcs/test_merkle_tree.cpp
@@ -25,6 +25,7 @@ merkle_tree<FieldT, hash_type> new_MT(
         size,
         std::make_shared<blake2b_leafhash<FieldT>>(security_parameter),
         blake2b_two_to_one_hash,
+        blake2b_vector_hash<binary_hash_digest>,
         digest_len_bytes,
         make_zk,
         security_parameter);
@@ -39,6 +40,7 @@ merkle_tree<FieldT, hash_type> new_MT(
         size,
         std::make_shared<dummy_algebraic_leafhash<FieldT>>(),
         dummy_algebraic_two_to_one_hash<FieldT>,
+        dummy_algebraic_cap_hash<FieldT>,
         digest_len_bytes,
         make_zk,
         security_parameter);


### PR DESCRIPTION
Cap hashing was implemented for merkle trees. The algebraic and non-algebraic cap hashes were both implemented in `hash_enum.tcc`, as well as the dummy algebraic hash. See issue https://github.com/scipr-lab/libiop/issues/41.

A bug was fixed that merkle tree membership proof generation and verification didn't work when the input queries weren't sorted and unique. They now work when the tree is not zero knowledge, but when the tree is set to be zero knowledge, the code still fails.

The hash count method was updated to count each two-to-one hash as 2 units and the cap hash as 1 unit per input.

More tests were added, to test cap hashing, and to test large trees with randomly generated query leaves. The code no not test unsorted non-unique queries since that still fails for zero knowledge trees.

No snark protocols currently take advantage of the cap hash; they still have cap size set to 2.

~Changes are complete, but not ready to merge because I started working based off of PR #43, so that should preferably be merged first.~ Ready for review