### PR TITLE
fix FRI benchmark and compilation with recent compilers

### DIFF
--- a/libiop/algebra/utils.hpp
+++ b/libiop/algebra/utils.hpp
@@ -8,6 +8,7 @@
 #ifndef LIBIOP_ALGEBRA_UTILS_HPP_
 #define LIBIOP_ALGEBRA_UTILS_HPP_
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/libiop/profiling/instrument_fri_snark.cpp
+++ b/libiop/profiling/instrument_fri_snark.cpp
@@ -29,11 +29,11 @@
 
 #ifndef CPPDEBUG
 bool process_prover_command_line(const int argc, const char** argv, options &options,
-                                 std::size_t localization_parameter,
-                                 std::size_t num_localization_steps,
-                                 std::size_t num_oracles,
-                                 std::size_t num_interactive_repetitions,
-                                 std::size_t num_query_repetitions)
+                                 std::size_t *localization_parameter,
+                                 std::size_t *num_localization_steps,
+                                 std::size_t *num_oracles,
+                                 std::size_t *num_interactive_repetitions,
+                                 std::size_t *num_query_repetitions)
 {
     namespace po = boost::program_options;
 
@@ -41,11 +41,11 @@ bool process_prover_command_line(const int argc, const char** argv, options &opt
     {
         po::options_description desc = gen_options(options);
         desc.add_options()
-            ("localization_parameter", po::value<std::size_t>(&localization_parameter)->default_value(2), "Only used when num_localization_steps is 0")
-            ("num_localization_steps", po::value<std::size_t>(&num_localization_steps)->default_value(0))
-            ("num_oracles", po::value<std::size_t>(&num_oracles)->default_value(1))
-            ("num_interactive_repetitions", po::value<std::size_t>(&num_interactive_repetitions)->default_value(1))
-            ("num_query_repetitions", po::value<std::size_t>(&num_query_repetitions)->default_value(64));
+            ("localization_parameter", po::value<std::size_t>(localization_parameter)->default_value(2), "Only used when num_localization_steps is 0")
+            ("num_localization_steps", po::value<std::size_t>(num_localization_steps)->default_value(0))
+            ("num_oracles", po::value<std::size_t>(num_oracles)->default_value(1))
+            ("num_interactive_repetitions", po::value<std::size_t>(num_interactive_repetitions)->default_value(1))
+            ("num_query_repetitions", po::value<std::size_t>(num_query_repetitions)->default_value(64));
 
         po::variables_map vm;
         po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -157,9 +157,9 @@ int main(int argc, const char * argv[])
     libff::UNUSED(argv);
 
 #else
-    if (!process_prover_command_line(argc, argv, default_vals, localization_parameter,
-                                     num_interactive_repetitions, num_query_repetitions,
-                                     num_localization_steps, num_oracles))
+    if (!process_prover_command_line(argc, argv, default_vals, &localization_parameter,
+                                     &num_interactive_repetitions, &num_query_repetitions,
+                                     &num_localization_steps, &num_oracles))
     {
         return 1;
     }

--- a/libiop/protocols/encoded/dummy_protocol.tcc
+++ b/libiop/protocols/encoded/dummy_protocol.tcc
@@ -22,8 +22,9 @@ std::shared_ptr<std::vector<FieldT>> dummy_oracle<FieldT>::evaluated_contents(
     }
 
     std::shared_ptr<std::vector<FieldT>> result = std::make_shared<std::vector<FieldT>>();
-    result->reserve(constituent_oracle_evaluations[0]->size());
-    for (size_t i = 0; i < result->size(); ++i)
+    const auto result_size = constituent_oracle_evaluations[0]->size();
+    result->reserve(result_size);
+    for (size_t i = 0; i < result_size; ++i)
     {
         result->emplace_back(FieldT::zero());
     }


### PR DESCRIPTION
Thanks for the useful library!

This PR fixes a couple issues I ran into:

1. `size_t` is defined in `<cstddef>`. Some C++ libraries will incidentally pull this in, but that's not guaranteed. Concretely, gcc-11 complains that `size_t` is undefined. The first commit in this PR fixes that.
2. `fri_iop` is broken---it segfaults; the second commit in this PR fixes it. A quick glance gives the impression that this issue has been in the codebase for a while. (To reproduce segfault: build current master branch and try to run `test_fri_optimizer` or `instrument_fri_snark`.
3. commandline option parsing is broken in `instrument_fri_snark`: the `localization_parameter`, `num_localization_steps`, `num_oracles`, `num_interactive_repetitions`, and `num_query_repetitions` arguments aren't handle properly. The third commit in this PR fixes it.
4. The `benchmark` dependency breaks with newer compiler/cmake combinations. Not 100% sure what versions break it, but it seems to be an interaction between the `CMAKE_CXX_STANDARD` and `CMAKE_CXX_STANDARD_REQUIRED` cmake flags and `cxx03_test.c` in `benchmark`. The fourth commit in this PR just updates `benchmark` to the latest version, which appears to work correctly and fixes the issue.