### PR TITLE
Remove #include <bits/stdc++.h>

### DIFF
--- a/libiop/bcs/merkle_tree.hpp
+++ b/libiop/bcs/merkle_tree.hpp
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <numeric>
 #include <vector>
-#include <bits/stdc++.h>
 
 #include "libiop/algebra/field_subset/field_subset.hpp"
 #include "libiop/bcs/hashing/hashing.hpp"


### PR DESCRIPTION
1. It's not portable
2. It's not needed anyway